### PR TITLE
Use geniURL for direct lyrics page URL lookup, then fall back to search page

### DIFF
--- a/apps/extension/src/app/Background/handleOnMessage.js
+++ b/apps/extension/src/app/Background/handleOnMessage.js
@@ -59,6 +59,26 @@ function handleOnMessage(message, sender, sendResponse) {
           chrome.search.query({ disposition: "NEW_TAB", text: value });
           break;
 
+        case "fetchLyricsMetadata": {
+          const abortController = new AbortController();
+          const timeout = setTimeout(() => abortController.abort(), 6000);
+
+          fetch(`https://api.sv443.net/geniurl/search/top?disableFuzzy&q=${value.query}`, {
+            method: "GET",
+            signal: abortController.signal,
+          })
+            .then((response) => response.json())
+            .then((data) => {
+              clearTimeout(timeout);
+              sendResponse({ success: true, data });
+            })
+            .catch(() => {
+              clearTimeout(timeout);
+              sendResponse({ success: false });
+            });
+          return true; // Keep the message channel open for async response
+        }
+
         default:
           console.log("default case");
           sendResponse("It's a me, the background script!");

--- a/apps/extension/src/app/Song/SongPanel/SongPanel.js
+++ b/apps/extension/src/app/Song/SongPanel/SongPanel.js
@@ -52,7 +52,8 @@ function SongPanel() {
       if (res.success && typeof res.data.url === "string" && res.data.url.startsWith("http")) url = res.data.url;
       else url = `https://genius.com/search?q=${query}`;
 
-      window.open(url, "_blank", "noopener noreferrer").focus();
+      const win = window.open(url, "_blank", "noopener noreferrer");
+      win && win.focus();
     });
   }
 

--- a/apps/extension/src/app/Song/SongPanel/SongPanel.js
+++ b/apps/extension/src/app/Song/SongPanel/SongPanel.js
@@ -43,9 +43,9 @@ function SongPanel() {
   }
 
   async function handleGeniusLyricsSearch(e) {
-    let modSongName = sanitize(metadata.title);
+    let songName = sanitize(metadata.title);
     let artistName = sanitize(metadata.artist);
-    let query = `${encodeURIComponent(artistName)}%20${encodeURIComponent(modSongName)}`;
+    let query = `${encodeURIComponent(songName)}%20${encodeURIComponent(artistName)}`;
     let url;
 
     chrome.runtime.sendMessage({ fetchLyricsMetadata: { query } }, (res) => {

--- a/apps/extension/src/app/Song/SongPanel/SongPanel.js
+++ b/apps/extension/src/app/Song/SongPanel/SongPanel.js
@@ -42,12 +42,18 @@ function SongPanel() {
     });
   }
 
-  function handleGeniusLyricsSearch(e) {
-    let modSongName = sanitize(metadata.title).replace(" ", "%20");
+  async function handleGeniusLyricsSearch(e) {
+    let modSongName = sanitize(metadata.title);
     let artistName = sanitize(metadata.artist);
-    let modArtistName = artistName.replace(" ", "%20");
-    let geniusUrlSearch = `https://genius.com/search?q=${modSongName}%20${modArtistName}`;
-    window.open(geniusUrlSearch, "_blank").focus();
+    let query = `${encodeURIComponent(artistName)}%20${encodeURIComponent(modSongName)}`;
+    let url;
+
+    chrome.runtime.sendMessage({ fetchLyricsMetadata: { query } }, (res) => {
+      if (res.success && typeof res.data.url === "string" && res.data.url.startsWith("http")) url = res.data.url;
+      else url = `https://genius.com/search?q=${query}`;
+
+      window.open(url, "_blank", "noopener noreferrer").focus();
+    });
   }
 
   return (


### PR DESCRIPTION
I know this seems kinda self-serving since I made the [geniURL API](https://github.com/Sv443/geniURL), so feel free to close this PR or edit it to your liking, but I still think it could streamline the process of opening the lyrics.  
Since YTM has a pretty tight content security policy, I made it so the fetch is done from the background script.  
  
These are the only problems I see:
- It takes a second or two between clicking the button and the lyrics page opening, so a pre-fetching step as soon as the ThemeSong dialog is opened or the /watch page loads would be better (or at least disabling the button and adding a spinner icon). If you want, I can implement that too, but I didn't wanna mess up your style of coding *too* much.
- The artist string in `navigator.mediaSession.metadata` includes all artists, which means 1) it's localized depending on which language is selected (meaning in German for example, it's separated with `und`, which the API doesn't recognize), and 2) only the primary artist should be provided to the genius API for better results. These are not just a problem with my approach, the current ThemeSong version also has these issues. For my YTM userscript I had to read the primary artist from the DOM directly, which is more prone to failure when they randomly decide to update the page, but it would solve this issue.

PS: love this extension, thank you for making it! :)