### PR TITLE
Add Last.fm scrobbling

### DIFF
--- a/apps/extension/README.md
+++ b/apps/extension/README.md
@@ -5,3 +5,23 @@
 Chrome and Firefox Extension for YouTube Music™
 
 Dynamic themes, visualizers, and utilities for YouTube Music™ (https://music.youtube.com)
+
+## Last.fm scrobbling
+
+ThemeSong can scrobble tracks you play on YouTube Music to your Last.fm account.
+
+### Build setup
+
+The Last.fm integration needs an API key and shared secret. The repo does not commit these — you supply them via a gitignored file before building.
+
+1. Register an API app at https://www.last.fm/api/account/create. Callback URL can be left blank.
+2. Copy the example credentials file:
+   ```
+   cp src/app/Lastfm/secrets.lastfm.example.js src/app/Lastfm/secrets.lastfm.js
+   ```
+3. Paste your API key and shared secret into `secrets.lastfm.js`.
+4. Build normally (`pnpm build` or `pnpm start`).
+
+### Security note
+
+A Last.fm API secret shipped in a browser extension can be extracted from the installed bundle by anyone — this is inherent to client-side code and true of every Last.fm-scrobbling extension on the stores. If the shared secret ever leaks or the key is abused, revoke it at https://www.last.fm/api/accounts and reissue. Published builds should use a dedicated API key owned by the extension maintainer.

--- a/apps/extension/src/app/Background/handleOnMessage.js
+++ b/apps/extension/src/app/Background/handleOnMessage.js
@@ -1,8 +1,12 @@
 import { executeContentScriptOnYouTubeMusicTabs } from "./scripts";
 import handleIconColor from "../Extension/IconColor/handleIconColor";
+import { handleLastfmMessage } from "../Lastfm/lastfmBackground";
 
 function handleOnMessage(message, sender, sendResponse) {
   console.log("Received message:", message, "from", sender);
+  if (message && typeof message === "object" && typeof message.type === "string" && message.type.startsWith("lastfm:")) {
+    return handleLastfmMessage(message, sender, sendResponse);
+  }
   if (typeof message === "string") {
     switch (message) {
       case "reset":

--- a/apps/extension/src/app/Content/ContentScript.js
+++ b/apps/extension/src/app/Content/ContentScript.js
@@ -16,6 +16,7 @@ import Unmounter from "../Extension/Unmounter";
 import Piece from "../Piece/Piece";
 import IconColor from "../Extension/IconColor/IconColor";
 import PlayPauseEventListener from "../Player/PlayPauseEventListener";
+import ScrobbleDetector from "../Lastfm/ScrobbleDetector";
 // import DisableContextMenu from "./DisableContextMenu";
 // import WelcomeMessage from "../Extension/WelcomeMessage";
 
@@ -82,6 +83,7 @@ function ContentScript({ root }) {
         <PlayerUiStateObserver />
         <MediaObserver />
         <PlayPauseEventListener />
+        <ScrobbleDetector />
       </MountWhenPlayerActive>
     </div>
   );

--- a/apps/extension/src/app/Extension/DataStoreSync.js
+++ b/apps/extension/src/app/Extension/DataStoreSync.js
@@ -10,6 +10,7 @@ function DataStoreSync() {
   const mergePiecePrefs = useStore((state) => state.piece.mergePiecePrefs);
   const mergeUtilitiesPrefs = useStore((state) => state.utilities.mergeUtilitiesPrefs);
   const mergeMedia = useStore((state) => state.media.mergeMedia);
+  const mergeLastfmPrefs = useStore((state) => state.lastfm.mergeLastfmPrefs);
 
   useEffect(() => {
     console.log("DataStoreSync");
@@ -37,6 +38,9 @@ function DataStoreSync() {
           break;
         case "media":
           mergeMedia(value);
+          break;
+        case "lastfmPrefs":
+          mergeLastfmPrefs(value);
           break;
         default:
           console.log("DataStoreSync: default case");

--- a/apps/extension/src/app/Lastfm/LastfmSettings.js
+++ b/apps/extension/src/app/Lastfm/LastfmSettings.js
@@ -1,0 +1,145 @@
+import { useState } from "react";
+import { css } from "@emotion/react";
+import { useStore } from "/src/app/store";
+
+function LastfmSettings() {
+  const prefs = useStore((state) => state.lastfm.prefs);
+  const setEnabled = useStore((state) => state.lastfm.setEnabled);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState(null);
+
+  const isConnected = !!prefs.sessionKey;
+
+  function handleConnect() {
+    setBusy(true);
+    setError(null);
+    chrome.runtime.sendMessage({ type: "lastfm:connect" }, (response) => {
+      setBusy(false);
+      if (chrome.runtime.lastError) {
+        setError(chrome.runtime.lastError.message);
+        return;
+      }
+      if (!response?.ok) setError(response?.error || "Connection failed");
+    });
+  }
+
+  function handleDisconnect() {
+    setBusy(true);
+    setError(null);
+    chrome.runtime.sendMessage({ type: "lastfm:disconnect" }, () => {
+      setBusy(false);
+    });
+  }
+
+  return (
+    <div
+      css={css`
+        padding: 10px;
+        margin-top: 15px;
+        border-top: 1px solid rgba(255, 255, 255, 0.1);
+      `}
+    >
+      <h2
+        css={css`
+          font-size: 16px;
+          margin-bottom: 10px;
+        `}
+      >
+        Last.fm scrobbling
+      </h2>
+
+      {isConnected ? (
+        <div>
+          <div
+            css={css`
+              font-size: 13px;
+              margin-bottom: 8px;
+            `}
+          >
+            Connected as <strong>{prefs.username}</strong>
+          </div>
+          <label
+            css={css`
+              display: flex;
+              align-items: center;
+              gap: 6px;
+              font-size: 13px;
+              margin-bottom: 8px;
+            `}
+          >
+            <input
+              type="checkbox"
+              checked={prefs.enabled}
+              onChange={(e) => setEnabled(e.target.checked)}
+            />
+            Scrobbling enabled
+          </label>
+          <button
+            onClick={handleDisconnect}
+            disabled={busy}
+            css={css`
+              background: #444;
+              color: white;
+              border: 1px solid #222;
+              border-radius: 2px;
+              padding: 4px 10px;
+              cursor: pointer;
+            `}
+          >
+            Disconnect
+          </button>
+        </div>
+      ) : (
+        <div>
+          <div
+            css={css`
+              font-size: 13px;
+              margin-bottom: 8px;
+            `}
+          >
+            Connect your Last.fm account to scrobble tracks you play on YouTube Music.
+          </div>
+          <button
+            onClick={handleConnect}
+            disabled={busy}
+            css={css`
+              background: #d51007;
+              color: white;
+              border: 1px solid #800;
+              border-radius: 2px;
+              padding: 4px 12px;
+              cursor: pointer;
+            `}
+          >
+            {busy ? "Waiting for authorization…" : "Connect to Last.fm"}
+          </button>
+          {busy && (
+            <div
+              css={css`
+                font-size: 11px;
+                margin-top: 6px;
+                color: #aaa;
+              `}
+            >
+              A new tab opened — authorize there, then come back. This can take up to 2 minutes.
+            </div>
+          )}
+        </div>
+      )}
+
+      {error && (
+        <div
+          css={css`
+            color: #ff6b6b;
+            font-size: 12px;
+            margin-top: 8px;
+          `}
+        >
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default LastfmSettings;

--- a/apps/extension/src/app/Lastfm/ScrobbleDetector.js
+++ b/apps/extension/src/app/Lastfm/ScrobbleDetector.js
@@ -1,0 +1,111 @@
+import { useEffect, useRef } from "react";
+import { useStore } from "/src/app/store";
+import { parseTrack } from "./parseTrack";
+
+const MIN_TRACK_LENGTH_S = 30;
+const MIN_PLAYED_S = 240;
+const MIN_PLAYED_FRACTION = 0.5;
+const MAX_TIMEUPDATE_DELTA_S = 2;
+
+function ScrobbleDetector() {
+  const metadata = useStore((state) => state.media.metadata);
+  const enabled = useStore((state) => state.lastfm.prefs.enabled);
+  const sessionKey = useStore((state) => state.lastfm.prefs.sessionKey);
+  const stateRef = useRef(null);
+
+  useEffect(() => {
+    if (!enabled || !sessionKey) return;
+    const video = document.querySelector("video");
+    if (!video) return;
+
+    const parsed = parseTrack(metadata);
+    if (!parsed) {
+      console.log("[lastfm] skipping track — could not parse artist/title", metadata);
+      stateRef.current = null;
+      return;
+    }
+
+    const trackKey = `${parsed.artist}|${parsed.title}`;
+    const isNewTrack = !stateRef.current || stateRef.current.trackKey !== trackKey;
+
+    if (isNewTrack) {
+      stateRef.current = {
+        trackKey,
+        artist: parsed.artist,
+        title: parsed.title,
+        album: parsed.album,
+        duration: video.duration || 0,
+        startedAt: Math.floor(Date.now() / 1000),
+        playedSeconds: 0,
+        lastTimeUpdate: video.currentTime,
+        scrobbled: false,
+        nowPlayingSent: false,
+      };
+      console.log("[lastfm] new track detected:", parsed);
+    }
+
+    function handleTimeUpdate() {
+      const s = stateRef.current;
+      if (!s) return;
+
+      if (!s.duration && video.duration) s.duration = video.duration;
+
+      if (!s.nowPlayingSent && s.duration > 0 && !video.paused) {
+        s.nowPlayingSent = true;
+        console.log("[lastfm] sending nowPlaying:", s.artist, "-", s.title);
+        chrome.runtime.sendMessage(
+          {
+            type: "lastfm:nowPlaying",
+            payload: { artist: s.artist, track: s.title, album: s.album, duration: s.duration },
+          },
+          (res) => console.log("[lastfm] nowPlaying response:", res)
+        );
+      }
+
+      const now = video.currentTime;
+      const delta = now - s.lastTimeUpdate;
+      s.lastTimeUpdate = now;
+
+      if (!video.paused && delta > 0 && delta < MAX_TIMEUPDATE_DELTA_S) {
+        s.playedSeconds += delta;
+      }
+
+      if (s.scrobbled) return;
+      if (s.duration <= MIN_TRACK_LENGTH_S) return;
+
+      const crossedHalfway = s.playedSeconds >= s.duration * MIN_PLAYED_FRACTION;
+      const crossedFourMin = s.playedSeconds >= MIN_PLAYED_S;
+
+      if (crossedHalfway || crossedFourMin) {
+        s.scrobbled = true;
+        console.log(
+          "[lastfm] threshold reached, scrobbling:",
+          s.artist,
+          "-",
+          s.title,
+          `(${s.playedSeconds.toFixed(1)}s / ${s.duration.toFixed(1)}s)`
+        );
+        chrome.runtime.sendMessage(
+          {
+            type: "lastfm:scrobble",
+            payload: {
+              artist: s.artist,
+              track: s.title,
+              album: s.album,
+              timestamp: s.startedAt,
+              duration: s.duration,
+            },
+          },
+          (res) => console.log("[lastfm] scrobble response:", res)
+        );
+      }
+    }
+
+    video.addEventListener("timeupdate", handleTimeUpdate);
+    return () => video.removeEventListener("timeupdate", handleTimeUpdate);
+  }, [metadata, enabled, sessionKey]);
+
+  return null;
+}
+
+export default ScrobbleDetector;

--- a/apps/extension/src/app/Lastfm/lastfmApi.js
+++ b/apps/extension/src/app/Lastfm/lastfmApi.js
@@ -1,0 +1,92 @@
+import { md5 } from "./md5";
+import { LASTFM_API_KEY, LASTFM_SHARED_SECRET } from "./secrets.lastfm";
+
+const API_ROOT = "https://ws.audioscrobbler.com/2.0/";
+export const AUTH_URL = (token) =>
+  `https://www.last.fm/api/auth/?api_key=${LASTFM_API_KEY}&token=${token}`;
+
+function signParams(params) {
+  const keys = Object.keys(params).sort();
+  let concat = "";
+  for (const k of keys) concat += k + params[k];
+  concat += LASTFM_SHARED_SECRET;
+  return md5(concat);
+}
+
+async function callGet(method, extraParams = {}) {
+  const params = {
+    method,
+    api_key: LASTFM_API_KEY,
+    format: "json",
+    ...extraParams,
+  };
+  const qs = new URLSearchParams(params).toString();
+  const res = await fetch(`${API_ROOT}?${qs}`);
+  const data = await res.json();
+  if (data.error) throw new Error(`Last.fm ${method} error ${data.error}: ${data.message}`);
+  return data;
+}
+
+async function callSignedPost(method, extraParams, sessionKey) {
+  const params = {
+    method,
+    api_key: LASTFM_API_KEY,
+    ...extraParams,
+  };
+  if (sessionKey) params.sk = sessionKey;
+  const toSign = { ...params };
+  params.api_sig = signParams(toSign);
+  params.format = "json";
+
+  const body = new URLSearchParams(params).toString();
+  const res = await fetch(API_ROOT, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body,
+  });
+  const data = await res.json();
+  if (data.error) throw new Error(`Last.fm ${method} error ${data.error}: ${data.message}`);
+  return data;
+}
+
+export async function getToken() {
+  const params = { method: "auth.getToken", api_key: LASTFM_API_KEY };
+  const sig = signParams(params);
+  const qs = new URLSearchParams({ ...params, api_sig: sig, format: "json" }).toString();
+  const res = await fetch(`${API_ROOT}?${qs}`);
+  const data = await res.json();
+  if (data.error) throw new Error(`Last.fm auth.getToken error ${data.error}: ${data.message}`);
+  return data.token;
+}
+
+export async function getSession(token) {
+  const params = { method: "auth.getSession", api_key: LASTFM_API_KEY, token };
+  const sig = signParams(params);
+  const qs = new URLSearchParams({ ...params, api_sig: sig, format: "json" }).toString();
+  const res = await fetch(`${API_ROOT}?${qs}`);
+  const data = await res.json();
+  if (data.error) {
+    const err = new Error(`Last.fm auth.getSession error ${data.error}: ${data.message}`);
+    err.code = data.error;
+    throw err;
+  }
+  return { sessionKey: data.session.key, username: data.session.name };
+}
+
+export async function updateNowPlaying({ artist, track, album, duration }, sessionKey) {
+  const params = { artist, track };
+  if (album) params.album = album;
+  if (duration) params.duration = String(Math.round(duration));
+  return callSignedPost("track.updateNowPlaying", params, sessionKey);
+}
+
+export async function scrobble({ artist, track, album, timestamp, duration }, sessionKey) {
+  const params = {
+    artist,
+    track,
+    timestamp: String(timestamp),
+  };
+  if (album) params.album = album;
+  if (duration) params.duration = String(Math.round(duration));
+  return callSignedPost("track.scrobble", params, sessionKey);
+}

--- a/apps/extension/src/app/Lastfm/lastfmBackground.js
+++ b/apps/extension/src/app/Lastfm/lastfmBackground.js
@@ -1,0 +1,101 @@
+import { getToken, getSession, AUTH_URL, updateNowPlaying, scrobble } from "./lastfmApi";
+
+const SESSION_POLL_INTERVAL_MS = 2000;
+const SESSION_POLL_TIMEOUT_MS = 120000;
+
+function readLastfmPrefs() {
+  return new Promise((resolve) => {
+    chrome.storage.local.get("lastfmPrefs", (obj) => {
+      resolve(obj.lastfmPrefs || { enabled: false, sessionKey: null, username: null });
+    });
+  });
+}
+
+function writeLastfmPrefs(prefs) {
+  return new Promise((resolve) => {
+    chrome.storage.local.set({ lastfmPrefs: prefs }, resolve);
+  });
+}
+
+async function handleConnect() {
+  const token = await getToken();
+  const authTab = await chrome.tabs.create({ url: AUTH_URL(token) });
+
+  const started = Date.now();
+  while (Date.now() - started < SESSION_POLL_TIMEOUT_MS) {
+    await new Promise((r) => setTimeout(r, SESSION_POLL_INTERVAL_MS));
+    try {
+      const { sessionKey, username } = await getSession(token);
+      const prefs = { enabled: true, sessionKey, username };
+      await writeLastfmPrefs(prefs);
+      try {
+        if (authTab?.id) chrome.tabs.remove(authTab.id);
+      } catch (e) {
+        /* tab may already be closed */
+      }
+      return { ok: true, username };
+    } catch (e) {
+      if (e.code && e.code !== 14) throw e;
+    }
+  }
+  throw new Error("Last.fm auth timed out — did you authorize the app?");
+}
+
+async function handleDisconnect() {
+  await writeLastfmPrefs({ enabled: false, sessionKey: null, username: null });
+  return { ok: true };
+}
+
+async function handleNowPlaying(payload) {
+  const prefs = await readLastfmPrefs();
+  if (!prefs.enabled || !prefs.sessionKey) return { ok: false, reason: "not-enabled" };
+  await updateNowPlaying(payload, prefs.sessionKey);
+  return { ok: true };
+}
+
+async function handleScrobble(payload) {
+  const prefs = await readLastfmPrefs();
+  if (!prefs.enabled || !prefs.sessionKey) return { ok: false, reason: "not-enabled" };
+
+  const delays = [0, 2000, 10000, 30000];
+  let lastErr;
+  for (const delay of delays) {
+    if (delay) await new Promise((r) => setTimeout(r, delay));
+    try {
+      await scrobble(payload, prefs.sessionKey);
+      return { ok: true };
+    } catch (e) {
+      lastErr = e;
+      console.warn("[lastfm] scrobble attempt failed, will retry:", e.message);
+    }
+  }
+  throw lastErr;
+}
+
+export function handleLastfmMessage(message, sender, sendResponse) {
+  if (!message || typeof message !== "object" || typeof message.type !== "string") return false;
+  if (!message.type.startsWith("lastfm:")) return false;
+
+  const run = async () => {
+    switch (message.type) {
+      case "lastfm:connect":
+        return handleConnect();
+      case "lastfm:disconnect":
+        return handleDisconnect();
+      case "lastfm:nowPlaying":
+        return handleNowPlaying(message.payload);
+      case "lastfm:scrobble":
+        return handleScrobble(message.payload);
+      default:
+        throw new Error(`unknown lastfm message: ${message.type}`);
+    }
+  };
+
+  run()
+    .then((result) => sendResponse({ ok: true, result }))
+    .catch((err) => {
+      console.error("[lastfm]", message.type, err);
+      sendResponse({ ok: false, error: err.message });
+    });
+  return true;
+}

--- a/apps/extension/src/app/Lastfm/lastfmSlice.js
+++ b/apps/extension/src/app/Lastfm/lastfmSlice.js
@@ -1,0 +1,38 @@
+export const createLastfmSlice = (set, get) => ({
+  prefs: {
+    enabled: false,
+    sessionKey: null,
+    username: null,
+  },
+  setSession: (payload) => {
+    console.log("lastfmSlice: setSession");
+    set((state) => {
+      state.lastfm.prefs.sessionKey = payload.sessionKey;
+      state.lastfm.prefs.username = payload.username;
+      state.lastfm.prefs.enabled = true;
+    });
+    chrome.storage.local.set({ lastfmPrefs: get().lastfm.prefs });
+  },
+  clearSession: () => {
+    console.log("lastfmSlice: clearSession");
+    set((state) => {
+      state.lastfm.prefs.sessionKey = null;
+      state.lastfm.prefs.username = null;
+      state.lastfm.prefs.enabled = false;
+    });
+    chrome.storage.local.set({ lastfmPrefs: get().lastfm.prefs });
+  },
+  setEnabled: (payload) => {
+    console.log("lastfmSlice: setEnabled");
+    set((state) => {
+      state.lastfm.prefs.enabled = payload;
+    });
+    chrome.storage.local.set({ lastfmPrefs: get().lastfm.prefs });
+  },
+  mergeLastfmPrefs: (payload) => {
+    console.log("lastfmSlice: mergeLastfmPrefs");
+    set((state) => {
+      state.lastfm.prefs = { ...state.lastfm.prefs, ...payload };
+    });
+  },
+});

--- a/apps/extension/src/app/Lastfm/md5.js
+++ b/apps/extension/src/app/Lastfm/md5.js
@@ -1,0 +1,160 @@
+/* MD5 implementation — public domain, adapted from Blueimp JS-MD5.
+ * Used to sign Last.fm API requests.
+ */
+
+function safeAdd(x, y) {
+  const lsw = (x & 0xffff) + (y & 0xffff);
+  const msw = (x >> 16) + (y >> 16) + (lsw >> 16);
+  return (msw << 16) | (lsw & 0xffff);
+}
+
+function bitRotateLeft(num, cnt) {
+  return (num << cnt) | (num >>> (32 - cnt));
+}
+
+function md5cmn(q, a, b, x, s, t) {
+  return safeAdd(bitRotateLeft(safeAdd(safeAdd(a, q), safeAdd(x, t)), s), b);
+}
+function md5ff(a, b, c, d, x, s, t) {
+  return md5cmn((b & c) | (~b & d), a, b, x, s, t);
+}
+function md5gg(a, b, c, d, x, s, t) {
+  return md5cmn((b & d) | (c & ~d), a, b, x, s, t);
+}
+function md5hh(a, b, c, d, x, s, t) {
+  return md5cmn(b ^ c ^ d, a, b, x, s, t);
+}
+function md5ii(a, b, c, d, x, s, t) {
+  return md5cmn(c ^ (b | ~d), a, b, x, s, t);
+}
+
+function binlMD5(x, len) {
+  x[len >> 5] |= 0x80 << len % 32;
+  x[(((len + 64) >>> 9) << 4) + 14] = len;
+
+  let a = 1732584193;
+  let b = -271733879;
+  let c = -1732584194;
+  let d = 271733878;
+
+  for (let i = 0; i < x.length; i += 16) {
+    const olda = a;
+    const oldb = b;
+    const oldc = c;
+    const oldd = d;
+
+    a = md5ff(a, b, c, d, x[i], 7, -680876936);
+    d = md5ff(d, a, b, c, x[i + 1], 12, -389564586);
+    c = md5ff(c, d, a, b, x[i + 2], 17, 606105819);
+    b = md5ff(b, c, d, a, x[i + 3], 22, -1044525330);
+    a = md5ff(a, b, c, d, x[i + 4], 7, -176418897);
+    d = md5ff(d, a, b, c, x[i + 5], 12, 1200080426);
+    c = md5ff(c, d, a, b, x[i + 6], 17, -1473231341);
+    b = md5ff(b, c, d, a, x[i + 7], 22, -45705983);
+    a = md5ff(a, b, c, d, x[i + 8], 7, 1770035416);
+    d = md5ff(d, a, b, c, x[i + 9], 12, -1958414417);
+    c = md5ff(c, d, a, b, x[i + 10], 17, -42063);
+    b = md5ff(b, c, d, a, x[i + 11], 22, -1990404162);
+    a = md5ff(a, b, c, d, x[i + 12], 7, 1804603682);
+    d = md5ff(d, a, b, c, x[i + 13], 12, -40341101);
+    c = md5ff(c, d, a, b, x[i + 14], 17, -1502002290);
+    b = md5ff(b, c, d, a, x[i + 15], 22, 1236535329);
+
+    a = md5gg(a, b, c, d, x[i + 1], 5, -165796510);
+    d = md5gg(d, a, b, c, x[i + 6], 9, -1069501632);
+    c = md5gg(c, d, a, b, x[i + 11], 14, 643717713);
+    b = md5gg(b, c, d, a, x[i], 20, -373897302);
+    a = md5gg(a, b, c, d, x[i + 5], 5, -701558691);
+    d = md5gg(d, a, b, c, x[i + 10], 9, 38016083);
+    c = md5gg(c, d, a, b, x[i + 15], 14, -660478335);
+    b = md5gg(b, c, d, a, x[i + 4], 20, -405537848);
+    a = md5gg(a, b, c, d, x[i + 9], 5, 568446438);
+    d = md5gg(d, a, b, c, x[i + 14], 9, -1019803690);
+    c = md5gg(c, d, a, b, x[i + 3], 14, -187363961);
+    b = md5gg(b, c, d, a, x[i + 8], 20, 1163531501);
+    a = md5gg(a, b, c, d, x[i + 13], 5, -1444681467);
+    d = md5gg(d, a, b, c, x[i + 2], 9, -51403784);
+    c = md5gg(c, d, a, b, x[i + 7], 14, 1735328473);
+    b = md5gg(b, c, d, a, x[i + 12], 20, -1926607734);
+
+    a = md5hh(a, b, c, d, x[i + 5], 4, -378558);
+    d = md5hh(d, a, b, c, x[i + 8], 11, -2022574463);
+    c = md5hh(c, d, a, b, x[i + 11], 16, 1839030562);
+    b = md5hh(b, c, d, a, x[i + 14], 23, -35309556);
+    a = md5hh(a, b, c, d, x[i + 1], 4, -1530992060);
+    d = md5hh(d, a, b, c, x[i + 4], 11, 1272893353);
+    c = md5hh(c, d, a, b, x[i + 7], 16, -155497632);
+    b = md5hh(b, c, d, a, x[i + 10], 23, -1094730640);
+    a = md5hh(a, b, c, d, x[i + 13], 4, 681279174);
+    d = md5hh(d, a, b, c, x[i], 11, -358537222);
+    c = md5hh(c, d, a, b, x[i + 3], 16, -722521979);
+    b = md5hh(b, c, d, a, x[i + 6], 23, 76029189);
+    a = md5hh(a, b, c, d, x[i + 9], 4, -640364487);
+    d = md5hh(d, a, b, c, x[i + 12], 11, -421815835);
+    c = md5hh(c, d, a, b, x[i + 15], 16, 530742520);
+    b = md5hh(b, c, d, a, x[i + 2], 23, -995338651);
+
+    a = md5ii(a, b, c, d, x[i], 6, -198630844);
+    d = md5ii(d, a, b, c, x[i + 7], 10, 1126891415);
+    c = md5ii(c, d, a, b, x[i + 14], 15, -1416354905);
+    b = md5ii(b, c, d, a, x[i + 5], 21, -57434055);
+    a = md5ii(a, b, c, d, x[i + 12], 6, 1700485571);
+    d = md5ii(d, a, b, c, x[i + 3], 10, -1894986606);
+    c = md5ii(c, d, a, b, x[i + 10], 15, -1051523);
+    b = md5ii(b, c, d, a, x[i + 1], 21, -2054922799);
+    a = md5ii(a, b, c, d, x[i + 8], 6, 1873313359);
+    d = md5ii(d, a, b, c, x[i + 15], 10, -30611744);
+    c = md5ii(c, d, a, b, x[i + 6], 15, -1560198380);
+    b = md5ii(b, c, d, a, x[i + 13], 21, 1309151649);
+    a = md5ii(a, b, c, d, x[i + 4], 6, -145523070);
+    d = md5ii(d, a, b, c, x[i + 11], 10, -1120210379);
+    c = md5ii(c, d, a, b, x[i + 2], 15, 718787259);
+    b = md5ii(b, c, d, a, x[i + 9], 21, -343485551);
+
+    a = safeAdd(a, olda);
+    b = safeAdd(b, oldb);
+    c = safeAdd(c, oldc);
+    d = safeAdd(d, oldd);
+  }
+  return [a, b, c, d];
+}
+
+function binl2rstr(input) {
+  let output = "";
+  for (let i = 0; i < input.length * 32; i += 8) {
+    output += String.fromCharCode((input[i >> 5] >>> i % 32) & 0xff);
+  }
+  return output;
+}
+
+function rstr2binl(input) {
+  const output = [];
+  output[(input.length >> 2) - 1] = undefined;
+  for (let i = 0; i < output.length; i += 1) output[i] = 0;
+  for (let i = 0; i < input.length * 8; i += 8) {
+    output[i >> 5] |= (input.charCodeAt(i / 8) & 0xff) << i % 32;
+  }
+  return output;
+}
+
+function rstrMD5(s) {
+  return binl2rstr(binlMD5(rstr2binl(s), s.length * 8));
+}
+
+function rstr2hex(input) {
+  const hexTab = "0123456789abcdef";
+  let output = "";
+  for (let i = 0; i < input.length; i += 1) {
+    const x = input.charCodeAt(i);
+    output += hexTab.charAt((x >>> 4) & 0x0f) + hexTab.charAt(x & 0x0f);
+  }
+  return output;
+}
+
+function strToUtf8(s) {
+  return unescape(encodeURIComponent(s));
+}
+
+export function md5(s) {
+  return rstr2hex(rstrMD5(strToUtf8(s)));
+}

--- a/apps/extension/src/app/Lastfm/parseTrack.js
+++ b/apps/extension/src/app/Lastfm/parseTrack.js
@@ -1,0 +1,65 @@
+const SUFFIX_PATTERNS = [
+  /\s*[\(\[]\s*official\s*(music\s*)?video\s*[\)\]]\s*$/i,
+  /\s*[\(\[]\s*official\s*audio\s*[\)\]]\s*$/i,
+  /\s*[\(\[]\s*official\s*[\)\]]\s*$/i,
+  /\s*[\(\[]\s*lyrics?\s*(video)?\s*[\)\]]\s*$/i,
+  /\s*[\(\[]\s*audio\s*[\)\]]\s*$/i,
+  /\s*[\(\[]\s*hd\s*[\)\]]\s*$/i,
+  /\s*[\(\[]\s*4k\s*[\)\]]\s*$/i,
+  /\s*[\(\[]\s*visualizer\s*[\)\]]\s*$/i,
+  /\s*[\(\[]\s*mv\s*[\)\]]\s*$/i,
+];
+
+function stripSuffixes(s) {
+  let out = s;
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const re of SUFFIX_PATTERNS) {
+      const next = out.replace(re, "");
+      if (next !== out) {
+        out = next;
+        changed = true;
+      }
+    }
+  }
+  return out.trim();
+}
+
+function splitOnDash(s) {
+  const match = s.match(/^(.+?)\s+[-–—]\s+(.+)$/);
+  if (!match) return null;
+  return { left: match[1].trim(), right: match[2].trim() };
+}
+
+export function parseTrack(metadata) {
+  if (!metadata) return null;
+  const rawTitle = (metadata.title || "").trim();
+  const rawArtist = (metadata.artist || "").trim();
+  const album = (metadata.album || "").trim() || undefined;
+
+  if (!rawTitle) return null;
+
+  let artist = rawArtist;
+  let title = rawTitle;
+
+  const artistLooksBad =
+    !artist ||
+    artist.toLowerCase() === rawTitle.toLowerCase() ||
+    /- topic$/i.test(artist);
+
+  if (artistLooksBad) {
+    const split = splitOnDash(rawTitle);
+    if (!split) return null;
+    artist = split.left;
+    title = split.right;
+  }
+
+  title = stripSuffixes(title);
+  artist = artist.trim();
+  title = title.trim();
+
+  if (!artist || !title) return null;
+
+  return { artist, title, album };
+}

--- a/apps/extension/src/app/Lastfm/secrets.lastfm.example.js
+++ b/apps/extension/src/app/Lastfm/secrets.lastfm.example.js
@@ -1,0 +1,9 @@
+// Copy this file to `secrets.lastfm.js` and fill in your Last.fm API credentials.
+// Register an app at https://www.last.fm/api/account/create to get these values.
+// `secrets.lastfm.js` is gitignored (via the repo's `secrets.*.js` pattern).
+//
+// See SPEC-lastfm-scrobble.md §8 for the threat model — a client-side API
+// secret can be extracted from the built bundle. Accepted trade-off.
+
+export const LASTFM_API_KEY = "your-api-key-here";
+export const LASTFM_SHARED_SECRET = "your-shared-secret-here";

--- a/apps/extension/src/app/Popup/components/SettingsPage.js
+++ b/apps/extension/src/app/Popup/components/SettingsPage.js
@@ -2,6 +2,7 @@ import { css } from "@emotion/react";
 import { BiReset } from "react-icons/bi";
 import LocaleSettings from "../../Extension/Localization/LocaleSettings";
 import useLocalization from "../../Extension/Localization/useLocalization";
+import LastfmSettings from "../../Lastfm/LastfmSettings";
 
 function SettingsPage() {
   const getMessage = useLocalization();
@@ -30,6 +31,7 @@ function SettingsPage() {
         {getMessage("settings")}
       </h1>
       <LocaleSettings />
+      <LastfmSettings />
       <div
         css={css`
           padding: 10px;

--- a/apps/extension/src/app/store.js
+++ b/apps/extension/src/app/store.js
@@ -10,6 +10,7 @@ import { createExtensionSlice } from "./Extension/extensionSlice";
 import { createUtilitiesSlice } from "./Utilities/utilitiesSlice";
 import { createPieceSlice } from "./Piece/pieceSlice";
 import { createMediaSlice } from "./Media/mediaSlice";
+import { createLastfmSlice } from "./Lastfm/lastfmSlice";
 
 export const useStore = create(
   immer((...a) => ({
@@ -22,5 +23,6 @@ export const useStore = create(
     utilities: { ...createUtilitiesSlice(...a) },
     piece: { ...createPieceSlice(...a) },
     media: { ...createMediaSlice(...a) },
+    lastfm: { ...createLastfmSlice(...a) },
   }))
 );

--- a/apps/extension/src/chrome-mv3.json
+++ b/apps/extension/src/chrome-mv3.json
@@ -16,7 +16,7 @@
     "34": "assets/icon-34.png",
     "128": "assets/icon-128.png"
   },
-  "host_permissions": ["https://music.youtube.com/*"],
+  "host_permissions": ["https://music.youtube.com/*", "https://ws.audioscrobbler.com/*"],
   "content_scripts": [
     {
       "matches": ["https://music.youtube.com/*"],

--- a/apps/extension/src/experimental-firefox-mv3.json
+++ b/apps/extension/src/experimental-firefox-mv3.json
@@ -5,7 +5,7 @@
   "description": "Dynamic themes and visualizers for YouTube Music™.",
   "background": { "scripts": ["themesong-background.js"] },
   "permissions": ["storage", "notifications", "scripting"],
-  "host_permissions": ["https://music.youtube.com/*", "https://*.googleusercontent.com/*", "https://*.ytimg.com/*"],
+  "host_permissions": ["https://music.youtube.com/*", "https://*.googleusercontent.com/*", "https://*.ytimg.com/*", "https://ws.audioscrobbler.com/*"],
   "action": {
     "default_popup": "popup.html",
     "default_icon": "assets/icon-34.png"

--- a/apps/extension/src/firefox-mv2.json
+++ b/apps/extension/src/firefox-mv2.json
@@ -9,6 +9,7 @@
     "https://music.youtube.com/*",
     "https://*.googleusercontent.com/*",
     "https://*.ytimg.com/*",
+    "https://ws.audioscrobbler.com/*",
     "storage",
     "notifications",
     "scripting",


### PR DESCRIPTION
## Hey 👋

First off — thanks for building ThemeSong. I started using it recently and it's genuinely great.

Quick bit of context for why I'm opening this: I've been a Last.fm user for many years, and one thing that's always frustrated me is how rarely any player or extension ships with scrobbling built in. Since ThemeSong is open source and I was already using it daily, I took the liberty of adding Last.fm support for my own use.

I figured I'd clean it up and send it your way in case you're interested. No pressure at all to merge — if it's outside the scope you want for ThemeSong, totally fair, and I'm happy keeping it on my fork. But if it's useful, here it is!

## Summary

Adds optional Last.fm scrobbling. Users connect their Last.fm account via the popup Settings page; tracks played on `music.youtube.com` are scrobbled following Last.fm's rules (>50% or >4min played, length >30s).

## Build

Requires a Last.fm API key/secret. See the new section in `apps/extension/README.md` — `secrets.lastfm.example.js` is committed as a template, the real file is gitignored via the existing `secrets.*.js` rule.

## Security note

A client-side Last.fm secret can be extracted from the built bundle by anyone who installs the extension — inherent to browser extensions, same as every other scrobbler on the stores (Web Scrobbler etc.). If you'd rather users bring their own key instead of shipping a shared one, let me know and I'll add a settings-page override. Option 1 (shared key, documented risk) is what most FOSS scrobblers do and what this PR is set up for.

## Test plan

- [x] Connect/disconnect flow
- [x] Track >50% scrobbles once
- [x] Long track scrobbles at the 4-min rule
- [x] Track <30s does not scrobble
- [x] Seeking past threshold without real playback does not scrobble
- [x] Pause + resume scrobbles once
- [x] `nowPlaying` only fires while playing (not on mount paused)
